### PR TITLE
Fix plugins support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ exports.outputFormat = 'markdown';
 
 exports.render = function (str, options, locals) {
   var opts = merge({}, options, locals);
-  var plugins = opts.plugins && Array.isArray(plugins) ? plugins : [plugins];
-  plugins.filter(Boolean).forEach(function (plugin) {
+  var plugins = opts.plugins && Array.isArray(opts.plugins) ? opts.plugins : [];
+  plugins.forEach(function (plugin) {
     mdast.use(plugin, opts);
   });
   return mdast.process(str, opts);

--- a/test/plugins/expected.md
+++ b/test/plugins/expected.md
@@ -1,6 +1,7 @@
 ---
 mdast:
   commonmark: true
+  strong: _
 ---
 
-2.  Some _emphasis_, **strongness**, and `code`.
+2.  Some _emphasis_, __strongness__, and `code`.

--- a/test/plugins/input.md
+++ b/test/plugins/input.md
@@ -1,6 +1,7 @@
 ---
 mdast:
   commonmark: true
+  strong: '_'
 ---
 
 2.  Some *emphasis*, **strongness**, and `code`.


### PR DESCRIPTION
On line 12, `plugins` was a null variable, so no plugin was ever used:

``` javascript
var plugins = opts.plugins && Array.isArray(plugins) ? plugins : [plugins];
```

`plugins` undefined.

This will fix it, and no longer require the `.filter` call.
